### PR TITLE
Support image manifest specification

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -84203,7 +84203,10 @@ function createDockerClient(registry) {
                 method: "HEAD",
                 headers: {
                     // Required for OCI images, which some namespaces use.
-                    Accept: "application/vnd.oci.image.index.v1+json",
+                    Accept: [
+                        "application/vnd.oci.image.index.v1+json",
+                        "application/vnd.oci.image.manifest.v1+json"
+                    ].join(",")
                 },
             });
             return result.ok;

--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -14,12 +14,19 @@ test("docker registry checker", async (t) => {
     t.equal(status, "ok");
   });
 
-  t.test("valid tag on OCI image", async (t) => {
+  t.test("valid image index OCI spec", async (t) => {
     const status = await check(
       "registry.uw.systems/data-platform/di-bigquery-connector:e3acca03cf16920eaca0828a93e6400aee98835a"
     );
     t.equal(status, "ok");
   });
+
+  t.test("valid image manifest OCI spec", async (t) => {
+    const status = await check(
+      "registry.uw.systems/auth/machine-api:61781b63e535dd7b91bd81a96713e5588fb534f8"
+    );
+    t.equal(status, "ok");
+  })
 
   t.test("non-existent tag", async (t) => {
     const status = await check(

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -115,7 +115,10 @@ function createDockerClient(registry: DockerRegistry): DockerClient {
         method: "HEAD",
         headers: {
           // Required for OCI images, which some namespaces use.
-          Accept: "application/vnd.oci.image.index.v1+json",
+          Accept: [
+            "application/vnd.oci.image.index.v1+json",
+            "application/vnd.oci.image.manifest.v1+json"
+          ].join(",")
         },
       });
       return result.ok;


### PR DESCRIPTION
Supports https://github.com/opencontainers/image-spec/blob/main/manifest.md

Was seeing `...does not exist. Is the tag correct?` even though a local `docker pull` worked fine. This PR fixes that.